### PR TITLE
Update chmod command in Makefile, working on Mac OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ pms:
 	# notify.zip.
 	mkdir zentaopms/www/data/notify/
 	# change mode.
-	chmod 777 -R zentaopms/tmp/
-	chmod 777 -R zentaopms/www/data
-	chmod 777 -R zentaopms/config
+	chmod -R 777 zentaopms/tmp/
+	chmod -R 777 zentaopms/www/data
+	chmod -R 777 zentaopms/config
 	chmod 777 zentaopms/module
 	chmod 777 zentaopms/www
 	chmod a+rx zentaopms/bin/*


### PR DESCRIPTION
Everything works fine on Linux. Things are different on my Mac(Mac EI Capitan). 

For the command 'chmod', you have to put the option '-R' in the front, such as 'chmod -R 777 zentaopms/tmp/' instead of 'chmod 777 -R zentaopms/tmp/'. Otherwise it won't work.

Thanks for your creative work.