### PR TITLE
GIT内文件名太长和中文文件名的处理

### DIFF
--- a/module/git/model.php
+++ b/module/git/model.php
@@ -426,8 +426,8 @@ class gitModel extends model
         $path = str_replace('%5C', '\\', $path);
 
         chdir($repo->path);
-        $subPath = substr($path, strlen($repo->path) + 1);
-        $subPath = ltrim($subPath, '/');
+        $subPath = substr($path, strlen($repo->path));
+        $subPath = urldecode(ltrim($subPath, '/'));
         exec("$this->client rev-list -n 2 $revision -- $subPath", $lists);
         if(count($lists) == 2) list($nowRevision, $preRevision) = $lists;
         $cmd = "$this->client diff $preRevision $nowRevision -- $subPath";
@@ -457,8 +457,8 @@ class gitModel extends model
         $path = str_replace('%3A', ':', $path);
         $path = str_replace('%5C', '\\', $path);
 
-        $subPath = substr($path, strlen($repo->path) + 1);
-        $subPath = ltrim($subPath, '/');
+        $subPath = substr($path, strlen($repo->path));
+        $subPath = urldecode(ltrim($subPath, '/'));
         chdir($repo->path);
         $cmd  = "$this->client show $revision:$subPath";
         $code = `$cmd`;

--- a/module/git/model.php
+++ b/module/git/model.php
@@ -282,11 +282,11 @@ class gitModel extends model
         chdir($this->repoRoot);
         if($fromRevision)
         {
-            $cmd = "$this->client log --stat $fromRevision..HEAD --pretty=format:%an*_*%cd*_*%H*_*%s";
+            $cmd = "$this->client log --stat=1024 $fromRevision..HEAD --pretty=format:%an*_*%cd*_*%H*_*%s";
         }
         else
         {
-            $cmd = "$this->client log  --stat --pretty=format:%an*_*%cd*_*%H*_*%s";
+            $cmd = "$this->client log  --stat=1024 --pretty=format:%an*_*%cd*_*%H*_*%s";
         }
         exec($cmd, $list, $return);
 


### PR DESCRIPTION
1.GIT仓库内文件名太长时，git log的stat需要加参数
2.中文文件名支持（不知道为何要strlen + 1，后面还有个ltrim斜杠的函数）