### PR TITLE
[bug修复]当计划绑定多个项目时，计划列表显示的总条数(recTotal)不正确，需进行去重处理

### DIFF
--- a/module/productplan/model.php
+++ b/module/productplan/model.php
@@ -88,7 +88,7 @@ class productplanModel extends model
             ->beginIF($browseType == 'unexpired')->andWhere('t1.end')->ge($date)->fi()
             ->beginIF($browseType == 'overdue')->andWhere('t1.end')->lt($date)->fi()
             ->orderBy($orderBy)
-            ->page($pager)
+            ->page($pager, 't1.id')
             ->fetchAll('id');
 
         if(!empty($plans))


### PR DESCRIPTION
当计划绑定多个项目时，计划列表显示的总条数(recTotal)不正确，需进行去重处理
原因如下：fetchall方法在循环时以$keyField作为键，重复的记录会覆盖，但是count方法直接获取执行sql替换字段后执行，需填入$distinctField去重