### PR TITLE
fix:修复ajax接口请求时非登录401错误

### DIFF
--- a/framework/api/entry.class.php
+++ b/framework/api/entry.class.php
@@ -18,6 +18,8 @@ class entry extends baseEntry
     {
         parent::__construct();
 
+        if($this->app->action == 'options') return $this->send(204);
+        
         if(!isset($this->app->user) or $this->app->user->account == 'guest') $this->sendError(401, 'Unauthorized');
 
         $this->dao = $this->loadModel('common')->dao;


### PR DESCRIPTION
 as been blocked by CORS policy: Response to preflight request doesn't pass access control check: It does not have HTTP ok status.