### PR TITLE
customize github proxy config

### DIFF
--- a/module/holiday/config.php
+++ b/module/holiday/config.php
@@ -4,4 +4,5 @@ $config->holiday->require = new stdclass();
 $config->holiday->require->create = 'name,begin,end';
 $config->holiday->require->edit   = 'name,begin,end';
 
-$config->holiday->apiRoot = 'https://ghproxy.com/https://raw.githubusercontent.com/NateScarlet/holiday-cn/master/%d.json';
+if(!isset($config->ghproxy)) $config->ghproxy = 'https://ghproxy.com/';
+$config->holiday->apiRoot = $config->ghproxy . 'https://raw.githubusercontent.com/NateScarlet/holiday-cn/master/%d.json';


### PR DESCRIPTION
Importing holidays is unavailable because ghproxy.com has been banned.
It may be better if proxy config allowed users to customize it in the settings