### PR TITLE
支持 Markdown 附件上传

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -156,7 +156,7 @@ $config->features->checkClient    = true;
 /* 文件上传设置。 Upload settings. */
 $config->file = new stdclass();
 $config->file->dangers     = 'php,php3,php4,phtml,php5,jsp,py,rb,asp,aspx,ashx,asa,cer,cdx,aspl,shtm,shtml,html,htm';
-$config->file->allowed     = 'txt,doc,docx,dot,wps,wri,pdf,ppt,pptx,xls,xlsx,ett,xlt,xlsm,csv,jpg,jpeg,png,psd,gif,ico,bmp,swf,avi,rmvb,rm,mp3,mp4,3gp,flv,mov,movie,rar,zip,bz,bz2,tar,gz,mpp,rp,pdm,vsdx,vsd,sql,xmind,mm';
+$config->file->allowed     = 'txt,md,doc,docx,dot,wps,wri,pdf,ppt,pptx,xls,xlsx,ett,xlt,xlsm,csv,jpg,jpeg,png,psd,gif,ico,bmp,swf,avi,rmvb,rm,mp3,mp4,3gp,flv,mov,movie,rar,zip,bz,bz2,tar,gz,mpp,rp,pdm,vsdx,vsd,sql,xmind,mm';
 $config->file->storageType = 'fs';         // fs or s3
 
 /* 文档多人协同配置。 Document Hocus Pocus. */

--- a/module/file/config.php
+++ b/module/file/config.php
@@ -2,6 +2,7 @@
 $config->file->mimes['xml']     = 'text/xml';
 $config->file->mimes['html']    = 'text/html';
 $config->file->mimes['csv']     = 'text/csv';
+$config->file->mimes['md']      = 'text/markdown';
 $config->file->mimes['default'] = 'application/octet-stream';
 
 $config->file->imageExtensions = array('jpeg', 'jpg', 'gif', 'png');

--- a/module/file/test/model/getextension.php
+++ b/module/file/test/model/getextension.php
@@ -11,6 +11,7 @@ cid=16509
 - 获取 3.ppt 的扩展名 @txt
 - 获取 4.txt 的扩展名 @mp4
 - 获取 5.zip 的扩展名 @zip
+- 获取 README.md 的扩展名 @md
 - 获取 1.php 的扩展名 @txt
 - 获取 2.phtml 的扩展名 @txt
 - 获取 3.jsp 的扩展名 @txt
@@ -32,6 +33,7 @@ r($file->getExtensionTest($fileNames[1]))      && p() && e('jpg');  // 获取 2.
 r($file->getExtensionTest($fileNames[2]))      && p() && e('txt');  // 获取 3.ppt 的扩展名
 r($file->getExtensionTest($fileNames[3]))      && p() && e('mp4');  // 获取 4.txt 的扩展名
 r($file->getExtensionTest($fileNames[4]))      && p() && e('zip');  // 获取 5.zip 的扩展名
+r($file->getExtensionTest('README.md'))        && p() && e('md');   // 获取 README.md 的扩展名
 r($file->getExtensionTest($errorFileNames[0])) && p() && e('txt');  // 获取 1.php 的扩展名
 r($file->getExtensionTest($errorFileNames[1])) && p() && e('txt');  // 获取 2.phtml 的扩展名
 r($file->getExtensionTest($errorFileNames[2])) && p() && e('txt');  // 获取 3.jsp 的扩展名


### PR DESCRIPTION
## 变更内容
- 默认附件允许列表增加 `md` 扩展名。
- 为 Markdown 文件增加 MIME 类型：`text/markdown`。
- 在 `getExtension` 单元测试中补充 `README.md -> md` 的用例。

## 背景说明
Markdown 文件属于常见的纯文本文件，很多团队会用它保存 PRD、技术方案、接口说明等文档。

当前默认白名单不包含 `md`，上传 `.md` 文件时会被降级为 `txt`。这会导致下载时文件名可能变成 `xxx.md.txt`，与用户上传的原始文件名不一致。

本次变更只放开 `md` 这一种低风险文本类扩展名，不涉及 `html/php` 等危险类型。

## 验证
已执行：
- `php -l config/config.php`
- `php -l module/file/config.php`
- `php -l module/file/test/model/getextension.php`

完整 model 测试未在 fresh clone 环境执行成功，原因是本地缺少测试数据库配置文件 `test/config/my.php`。
