### PR TITLE
fix: 修复 PHP 8.2 下 bug 模块因 session 异常值导致的 TypeError

### DIFF
--- a/module/bug/control.php
+++ b/module/bug/control.php
@@ -64,7 +64,9 @@ class bug extends control
         {
             $tab      = ($this->app->tab == 'project' or $this->app->tab == 'execution') ? $this->app->tab : 'qa';
             $mode     = (strpos(',create,edit,', ",{$this->app->methodName},") !== false and empty($this->config->CRProduct)) ? 'noclosed' : '';
-            $objectID = ($tab == 'project' or $tab == 'execution') ? $this->session->{$tab} : 0;
+            $objectID = ($tab == 'project' or $tab == 'execution') ? zget($this->session, $tab, 0) : 0;
+            if($objectID === false || $objectID === null) $objectID = 0;
+            if(is_string($objectID) && $objectID === '') $objectID = 0;
             if($tab == 'project' or $tab == 'execution')
             {
                 if(common::isTutorialMode())


### PR DESCRIPTION
## 问题描述

在 PHP 8.2 环境下，访问 Bug 相关页面时，`bug` 模块构造函数会根据当前 tab 从 session 读取 `project/execution`，并将其传给 `productModel::getProducts()`。

当前代码直接读取：

```php
$objectID = ($tab == 'project' or $tab == 'execution') ? $this->session->{$tab} : 0;
```

当 session 中的 `project` 或 `execution` 异常为 `false`、`null` 或空字符串时，会继续传入：

```php
$this->product->getProducts($objectID, $mode, '', false);
```

而 `productModel::getProducts()` 在 PHP 8.2 下带有更严格的参数类型约束，`bool` 传入后会直接触发 `TypeError`，导致页面 fatal error。

报错示例：

```text
Uncaught TypeError: productModel::getProducts(): Argument #1 ($projectID) must be of type array|int, bool given
```

## 修复方案

在 `module/bug/control.php` 中为 session 读取结果增加兜底处理：

- 使用 `zget()` 读取 session 值
- 将 `false`、`null`、空字符串统一归一为 `0`
- 保证传入 `getProducts()` 的始终是合法的 `int|array`

修复后不改变正常业务逻辑，仅在 session 异常值场景下回退到默认值，避免 PHP 8.2 下的致命错误。

## 影响范围

- 仅影响 `bug` 模块初始化时对 session 中 `project/execution` 的读取
- 不改变正常页面逻辑
- 仅修复异常 session 值在 PHP 8.2 下触发的兼容性问题

## 验证

- 代码修改后可正常通过 `php -l`
- 在 session 值异常时不再向 `getProducts()` 传入 `false`
- 正常路径下页面行为不变
