### PR TITLE
fix: 修复权限组视野变更后用户视图未刷新的问题

### DIFF
--- a/module/group/model.php
+++ b/module/group/model.php
@@ -526,6 +526,21 @@ class groupModel extends model
 
         $actions = empty($actions) ? '' : json_encode($actions);
         $this->dao->update(TABLE_GROUP)->set('acl')->eq($actions)->where('id')->eq($groupID)->exec();
+
+        if(!dao::isError())
+        {
+            $accounts = $this->dao->select('account')->from(TABLE_USERGROUP)->where('`group`')->eq($groupID)->fetchPairs();
+            $this->loadModel('setting')->setItem('system.common.userview.relatedTablesUpdateTime', time());
+            $this->loadModel('user');
+            foreach($accounts as $account)
+            {
+                if(!$account) continue;
+                $rights   = $this->user->authorize($account);
+                $userView = $this->user->grantUserView($account, zget($rights, 'acls', array()), zget($rights, 'projects', ''));
+                $this->dao->replace(TABLE_USERVIEW)->data($userView)->exec();
+            }
+        }
+
         return !dao::isError();
     }
 
@@ -654,7 +669,6 @@ class groupModel extends model
         $delUsers   = array_diff($groupUsers, $members);
 
         if(!empty($delUsers)) $this->dao->delete()->from(TABLE_USERGROUP)->where('`group`')->eq($groupID)->andWhere('account')->in($delUsers)->exec();
-        if(empty($newUsers)) return !dao::isError();
 
         $data = new stdclass();
         $data->group   = $groupID;
@@ -663,6 +677,23 @@ class groupModel extends model
         {
             $data->account = $account;
             $this->dao->insert(TABLE_USERGROUP)->data($data)->exec();
+        }
+
+        if(!dao::isError())
+        {
+            $affectedUsers = array_merge($newUsers, $delUsers);
+            if(!empty($affectedUsers))
+            {
+                $this->loadModel('setting')->setItem('system.common.userview.relatedTablesUpdateTime', time());
+                $this->loadModel('user');
+                foreach($affectedUsers as $account)
+                {
+                    if(!$account) continue;
+                    $rights   = $this->user->authorize($account);
+                    $userView = $this->user->grantUserView($account, zget($rights, 'acls', array()), zget($rights, 'projects', ''));
+                    $this->dao->replace(TABLE_USERVIEW)->data($userView)->exec();
+                }
+            }
         }
 
         return !dao::isError();
@@ -1075,13 +1106,16 @@ class groupModel extends model
                 {
                     /* Show related privs when select. */
                     if($type == 'recommend' && in_array($privCode, $recommendSelect)) $relatedPrivs[$type][$privCode] = $privCode;
-                    if($type == 'depend') $depends[$privCode] = $priv['depend'];
 
                     if(!in_array($privCode, $selectedPrivList) || !isset($priv[$type])) continue;
 
-                    foreach($priv[$type] as $relatedPriv)
+                    foreach($priv[$type] as $code => $relatedPriv)
                     {
-                        if(!in_array($relatedPriv, $selectedPrivList) && in_array($relatedPriv, $allPrivList)) $relatedPrivs[$type][$relatedPriv] = $relatedPriv;
+                        if(!in_array($relatedPriv, $selectedPrivList) && in_array($relatedPriv, $allPrivList))
+                        {
+                            $relatedPrivs[$type][$relatedPriv] = $relatedPriv;
+                            if($type == 'depend') $depends[$privCode][$code] = $relatedPriv;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 问题描述

在权限组中维护“视野权限”或调整组成员后，系统会更新：

- `zt_group.acl`
- `zt_usergroup`

但不会同步刷新受影响用户的最终 `user view`（`zt_userview`）。

这会导致一种常见的不一致：

- 页面上的组视野配置已经包含某个产品/项目/执行
- 但用户实际生效的 `user view` 仍然是旧值
- 后续页面查询、接口调用、对象访问校验仍可能按旧视图过滤

在实际使用中，这会表现为：

- 组视野里已经勾选了某个产品
- 用户仍然无法通过页面或 API 访问该产品下的数据
- 尤其是依赖 `app->user->view` 的产品、需求、文档等读取接口，会继续报无权限或查不到数据

## 根因分析

`module/group/model.php` 中：

1. `updateView()` 只更新了 `zt_group.acl`，没有刷新该组成员的最终 `user view`
2. `updateUser()` 只更新了成员关系，没有刷新新增/移除成员的最终 `user view`

而系统中多个模块会直接依赖 `app->user->view` 或 `zt_userview` 做访问过滤，因此组视野与用户实际可见范围会出现滞后。

## 修复方案

在以下两个入口补充用户视图刷新：

1. `updateView()`
   - 组视野保存成功后，取出该组全部成员
   - 重新计算并持久化每个成员的最终 `user view`

2. `updateUser()`
   - 组成员增删成功后，取出所有受影响用户（新增和删除）
   - 重新计算并持久化这些用户的最终 `user view`

刷新逻辑使用：

- `authorize($account)` 获取组视野 ACL
- `grantUserView($account, $rights['acls'], $rights['projects'])` 生成最终视图
- 将最终结果写回 `zt_userview`

同时更新：

- `system.common.userview.relatedTablesUpdateTime`

用于保证相关缓存失效时间与视图变更保持一致。

## 影响范围

- 仅影响组视野维护、组成员维护后的权限同步逻辑
- 不改变原有权限模型
- 仅修复“组配置已修改，但用户实际视图未刷新”的不一致问题

## 风险评估

风险较低。

本次修改不改变权限判定规则，只是在组视野和组成员发生变更后，主动刷新受影响用户的最终视图，避免页面配置与实际访问结果不一致。
