### PR TITLE
修复 formdom 在 PHP 8.2+ 下的编码兼容问题

### DIFF
--- a/lib/formdom/formdom.class.php
+++ b/lib/formdom/formdom.class.php
@@ -68,7 +68,7 @@ class formdom
 
         $dom = new DOMDocument();
         libxml_use_internal_errors(true);
-        @$dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
+        @$dom->loadHTML($this->encodeHtmlForDom($html));
         libxml_clear_errors();
 
         $xpath = new DOMXPath($dom);
@@ -109,6 +109,25 @@ class formdom
         /* 提取表单数据 */
         $result = $this->extractFormData($xpath, $form);
         return $result;
+    }
+
+    /**
+     * Encode non-ASCII characters before passing HTML to DOMDocument.
+     *
+     * PHP 8.2+ deprecates mb_convert_encoding(..., 'HTML-ENTITIES', ...).
+     *
+     * @param  string $html
+     * @access private
+     * @return string
+     */
+    private function encodeHtmlForDom($html)
+    {
+        if(function_exists('mb_encode_numericentity'))
+        {
+            return mb_encode_numericentity($html, array(0x80, 0x10FFFF, 0, 0x10FFFF), 'UTF-8');
+        }
+
+        return mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
     }
 
     /**

--- a/module/misc/test/zen/formdomparse.php
+++ b/module/misc/test/zen/formdomparse.php
@@ -1,0 +1,35 @@
+#!/usr/bin/env php
+<?php
+
+/**
+
+title=测试 formdom 解析 UTF-8 表单片段;
+timeout=0
+cid=1
+
+- 解析包含中文和 HTML 的表单 >> 中文标题
+- 解析包含中文和 HTML 的表单 >> 第一行第二行
+
+*/
+
+include dirname(__FILE__, 5) . '/lib/formdom/formdom.class.php';
+
+function testFormdomParse(): array
+{
+    $parser = new formdom();
+    $html   = <<<HTML
+<form id="caseForm">
+  <input type="text" name="title" value="中文标题" />
+  <textarea name="desc">第一行<p>第二行</p></textarea>
+</form>
+HTML;
+
+    return $parser->parse($html, 'caseForm');
+}
+
+$result = testFormdomParse();
+
+if(!isset($result['title']) || $result['title'] !== '中文标题') exit("FAIL title\n");
+if(!isset($result['desc']) || $result['desc'] !== '第一行第二行') exit("FAIL desc\n");
+
+echo "PASS\n";


### PR DESCRIPTION
## 变更说明
- 修复 `formdom` 在 PHP 8.2+ 环境下使用 `mb_convert_encoding(..., 'HTML-ENTITIES', ...)` 触发弃用告警的问题
- 在传给 `DOMDocument::loadHTML()` 之前，优先使用 `mb_encode_numericentity()` 对非 ASCII 字符进行编码
- 补充一个最小回归测试，覆盖包含中文和 HTML 片段的表单解析场景

## 背景
API 在处理 `create/edit/change` 这类请求时，会先渲染 HTML 表单，再通过 `formdom` 解析默认值。在 PHP 8.2+ 下，旧的 `mb_convert_encoding(..., 'HTML-ENTITIES', ...)` 会产生 warning，进而污染 API 响应体，并触发后续 `ob_clean()` / `header()` 的连锁告警。

## 影响
- 不改变 `formdom` 的既有解析行为
- 避免 PHP 8.2+ 下 API 响应被 warning 污染
- 对依赖 `formdom` 的其他表单解析路径同样生效

## 验证
- `php module/misc/test/zen/formdomparse.php`
- `php -l lib/formdom/formdom.class.php`
- `php -l module/misc/test/zen/formdomparse.php`
