### PR TITLE
修复测试单 API 权限校验

### DIFF
--- a/framework/api/router.class.php
+++ b/framework/api/router.class.php
@@ -431,6 +431,11 @@ class api extends router
             case TABLE_BUILD:
             case TABLE_TASK:
                 return (!$object->execution || strpos(",{$userView->sprints},", ",$object->execution,") !== false);
+            case TABLE_TESTTASK:
+                $projects = ",{$userView->sprints},{$userView->projects},";
+                return (!$object->product || strpos(",{$userView->products},", ",$object->product,") !== false)
+                    && (!$object->project || strpos($projects, ",$object->project,") !== false)
+                    && (!$object->execution || strpos(",{$userView->sprints},", ",$object->execution,") !== false);
             default:
                 return true;
         }
@@ -480,6 +485,8 @@ class api extends router
             'caseID'        => TABLE_CASE,
             'testcase'      => TABLE_CASE,
             'testcaseID'    => TABLE_CASE,
+            'testtask'      => TABLE_TESTTASK,
+            'testtaskID'    => TABLE_TESTTASK,
             'user'          => TABLE_USER,
             'userID'        => TABLE_USER,
             'ticket'        => TABLE_TICKET,
@@ -487,6 +494,8 @@ class api extends router
             'dept'          => TABLE_DEPT,
             'deptID'        => TABLE_DEPT,
         ];
+
+        if($this->rawModule == 'testtask') $objectMap['taskID'] = TABLE_TESTTASK;
 
         /* Check assignedTo. */
         if(isset($_POST['assignedTo']) && $_POST['assignedTo'])

--- a/test/api/testtasks/delete.php
+++ b/test/api/testtasks/delete.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php
+include dirname(dirname(dirname(__FILE__))) . '/lib/init.php';
+
+/**
+
+title=测试API 删除测试单;
+cid=1
+pid=1
+
+使用正确测试单id删除测试单 >> {"message":"success"}
+查询已删除的测试单信息 >> 1,1
+
+*/
+global $token;
+$header = array('Token' => $token->token);
+
+$deleteExist = $rest->delete('/testtasks/1', $header);
+
+r($deleteExist) && c(200) && p() && e('{"message":"success"}'); // 使用正确测试单id删除测试单
+
+$existTesttask = $rest->get('/testtasks/1', $header);
+$existTesttask->body = array($existTesttask->body);
+
+r($existTesttask) && c(200) && p('id,deleted') && e('1,1'); // 查询已删除的测试单信息


### PR DESCRIPTION
## 概述
- 在 API v2 访问校验中增加测试单对象映射。
- 按产品、项目和执行权限校验测试单访问权限。
- 在 testtask 模块中将 taskID 参数按测试单 ID 处理，兼容测试单控制器的历史形参命名。
- 增加删除测试单的 API 回归测试。

## 验证
- php -l framework/api/router.class.php
- php -l test/api/testtasks/delete.php
- git diff --check