### PR TITLE
[api] Fix file upload method.

### DIFF
--- a/api/v1/entries/files.php
+++ b/api/v1/entries/files.php
@@ -22,7 +22,9 @@ class filesEntry extends entry
         $uid = $this->param('uid', '');
 
         $control = $this->loadController('file', 'ajaxUpload');
-        $control->ajaxUpload($uid);
+        $objectType = isset($_POST['objectType']) ? $_POST['objectType'] : '';
+        $objectID = isset($_POST['objectID']) ? $_POST['objectID'] : 0;
+        $control->ajaxUpload($uid, $objectType, $objectID);
 
         $data = $this->getData();
 


### PR DESCRIPTION
fix file upload method. 

api文档显示，附件上传接口有objectID和objectType字段，实际源码里缺少这俩字段的提取。


<img width="1329" height="938" alt="image" src="https://github.com/user-attachments/assets/7afa681a-f2eb-40e9-a8bf-a88c71d25e39" />
