### PR TITLE
* api: fix DELETE /tasks/{id} deleting nothing

### DIFF
--- a/api/v1/entries/task.php
+++ b/api/v1/entries/task.php
@@ -134,7 +134,7 @@ class taskEntry extends entry
     public function delete($taskID)
     {
         $control = $this->loadController('task', 'delete');
-        $control->delete(0, $taskID, 'true');
+        $control->delete($taskID);
 
         $this->getData();
         return $this->sendSuccess(200, 'success');


### PR DESCRIPTION
## 问题

REST API `DELETE /api.php/v1/tasks/{id}` 返回 `{"message":"success"}`，但任务并没有被删除（`zt_task.deleted` 仍为 0，也没有 `deleted` 的 action 记录）。

原因：`api/v1/entries/task.php` 仍按旧签名调用控制器：

```php
$control->delete(0, $taskID, 'true');
```

而 `module/task/control.php` 现在是 `delete(int $taskID, string $from = '')`，于是实际删除的是 ID 为 0 的任务。`bug.php`、`story.php`、`todo.php` 三个入口都已经改成把 ID 作为第一个参数传入，只有 task 漏掉了。

## 修改

```php
$control->delete($taskID);
```

## 验证

在 22.5（`easysoft/zentao:22.5-20260821-php7`）上打此补丁后：`POST /executions/{id}/tasks` 创建任务 → `DELETE /tasks/{id}` 返回 200 → `GET /tasks/{id}` 返回 `deleted: true`，`zt_action` 中出现 `deleted` 记录；修改前 `GET` 仍返回 `deleted: false`。

---

**Summary (EN):** `DELETE /tasks/{id}` reported success but never deleted the task because the API entry still used the pre-22 controller signature `delete(0, $taskID, 'true')`; the controller is now `delete(int $taskID, string $from = '')`, so task 0 was targeted. Pass `$taskID` as the first argument like the bug/story/todo entries do. Verified on 22.5.
