### PR TITLE
* api: set storyType when creating a project

### DIFF
--- a/api/v1/entries/projects.php
+++ b/api/v1/entries/projects.php
@@ -96,6 +96,11 @@ class projectsEntry extends entry
         $this->setPost('model', $this->request('model', 'scrum'));
         $this->setPost('parent', $this->request('parent', 0));
 
+        /* The create form always posts storyType, the API does not; default it the same way the form does. */
+        $projectModel     = $this->request('model', 'scrum');
+        $defaultStoryType = in_array($projectModel, array('waterfall', 'waterfallplus', 'ipd')) ? 'story,requirement' : 'story';
+        $this->setPost('storyType', $this->request('storyType', $defaultStoryType));
+
         $requireFields = 'name,begin,end,products';
         if($useCode) $requireFields .= ',code';
         $this->requireFields($requireFields);


### PR DESCRIPTION
## 问题

通过 `POST /api.php/v1/projects` 创建的项目，`zt_project.storyType` 是**空字符串**；在界面上创建的同类项目是 `story`（表结构该列的默认值也是 `story`）。

```sql
-- 界面创建
| id | name         | model     | storyType         |
|  5 | project-a    | agileplus | story             |
|  2 | project-b    | scrum     | story,requirement |
-- API 创建
| 97 | api project  | scrum     |                   |
```

后果不只是字段难看：`executionModel::linkStory()` 用

```php
if(strpos($project->storyType, "$story->type") === false && $this->config->vision == 'rnd') continue;
```

过滤候选需求，`storyType` 为空时 `strpos('', 'story')` 返回 `false`，于是**所有需求都被跳过**。这样的项目，其迭代永远关联不上需求——不只是 API，**在网页上手工关联同样无效**，而且没有任何报错。

## 原因

`projectZen::prepareCreateExtras()` 里有一行正是为这种情况准备的：

```php
->setDefault('storyType', 'story') // API post data has no storyType.
```

但它对 API 请求并未生效（API 创建出来的项目该字段仍为空，实测如上）。因为不确定 `form::data()` 在缺少该字段时产出的具体形态，这里选择在 API 入口显式设置，改动范围最小、不触碰界面共用的代码路径。如果维护者认为应当修在 `prepareCreateExtras()`，我很乐意改成那种方式。

## 修改

在 `api/v1/entries/projects.php` 的 `post()` 里补上该字段，默认值与 `module/project/ui/create.field.php:66` 的界面逻辑保持一致（瀑布/瀑布plus/IPD 为 `story,requirement`，其余为 `story`），同时允许调用方显式传入：

```php
$projectModel     = $this->request('model', 'scrum');
$defaultStoryType = in_array($projectModel, array('waterfall', 'waterfallplus', 'ipd')) ? 'story,requirement' : 'story';
$this->setPost('storyType', $this->request('storyType', $defaultStoryType));
```

## 验证

在 22.5（`easysoft/zentao:22.5-20260821-php7`）上：

- 打补丁前：`POST /projects`（model=scrum）→ `storyType` 为空 → 该项目下的迭代关联需求，接口返回成功但需求列表始终为空。
- 打补丁后：`storyType` 为 `story` → 同样的操作，迭代需求列表正确返回 3 条。

---

**Summary (EN):** Projects created via `POST /projects` get an empty `storyType` (the UI and the column default both use `story`). `executionModel::linkStory()` filters stories with `strpos($project->storyType, $story->type)`, so an empty value silently skips every story — such a project can never link stories to an execution, via the API *or* the web UI. `projectZen::prepareCreateExtras()` has a `setDefault('storyType', 'story')` commented "API post data has no storyType" that does not take effect for API requests, so set the field in the entry, defaulting it the same way `project/ui/create.field.php` does. Verified on 22.5.

