### PR TITLE
+ api: link and unlink stories on an execution

### DIFF
--- a/api/v1/entries/executionstories.php
+++ b/api/v1/entries/executionstories.php
@@ -47,4 +47,58 @@ class executionStoriesEntry extends entry
 
         return $this->sendError(400, 'error');
     }
+
+    /**
+     * POST method: link stories to the execution.
+     *
+     * @param  int    $executionID
+     * @access public
+     * @return string
+     */
+    public function post($executionID)
+    {
+        if(empty($executionID)) return $this->sendError(400, 'Need execution id.');
+
+        if(!commonModel::hasPriv('execution', 'linkStory')) return $this->sendError(403, 'Access not allowed.');
+
+        $stories = $this->request('stories', array());
+        if(!is_array($stories)) $stories = array_filter(explode(',', (string)$stories));
+        $stories = array_values(array_filter(array_map('intval', $stories)));
+        if(empty($stories)) return $this->sendError(400, 'Need stories.');
+
+        $executionModel = $this->loadModel('execution');
+        $execution      = $executionModel->getByID($executionID);
+        if(empty($execution)) return $this->sendError(404, 'Execution not found.');
+
+        /* Same order as executionModel::linkStories(): a story has to be linked to the project as well. */
+        if($execution->type != 'project' and !empty($execution->project)) $executionModel->linkStory((int)$execution->project, $stories);
+        $executionModel->linkStory((int)$executionID, $stories);
+        if(dao::isError()) return $this->sendError(400, dao::getError());
+
+        return $this->send(201, array('execution' => (int)$executionID, 'stories' => $stories));
+    }
+
+    /**
+     * DELETE method: unlink a story from the execution.
+     *
+     * @param  int    $executionID
+     * @param  int    $storyID
+     * @access public
+     * @return string
+     */
+    public function delete($executionID, $storyID)
+    {
+        if(empty($executionID)) return $this->sendError(400, 'Need execution id.');
+        if(empty($storyID))     return $this->sendError(400, 'Need story id.');
+        if(!commonModel::hasPriv('execution', 'unlinkStory')) return $this->sendError(403, 'Access not allowed.');
+
+        $executionModel = $this->loadModel('execution');
+        $execution      = $executionModel->getByID($executionID);
+        if(empty($execution)) return $this->sendError(404, 'Execution not found.');
+
+        $executionModel->unlinkStory((int)$executionID, (int)$storyID);
+        if(dao::isError()) return $this->sendError(400, dao::getError());
+
+        return $this->sendSuccess(200, 'success');
+    }
 }

--- a/config/apiv1.php
+++ b/config/apiv1.php
@@ -58,6 +58,7 @@ $routes['/stories']                     = 'stories';
 $routes['/products/:id/stories']        = 'stories';
 $routes['/projects/:id/stories']        = 'projectStories';
 $routes['/executions/:id/stories']      = 'executionStories';
+$routes['/executions/:id/stories/:storyID'] = 'executionStories';
 $routes['/stories/:id']                 = 'story';
 $routes['/stories/:id/change']          = 'storyChange';
 $routes['/stories/:id/close']           = 'storyClose';


### PR DESCRIPTION
## 背景

把需求关联进迭代是禅道的核心功能，但 REST API v1 既不能关联也不能解除：

- `api/v1/entries/executionstories.php` 只实现了 `get()`，能读不能写；
- `config/apiv1.php` 里也没有别的入口，唯一的 `linkstories` 是 `/productplans/:id/linkstories`，关联的是**产品计划**而不是迭代。

给 `POST /projects/:id/executions` 传 `plans` 也不行。界面流程里，计划下的需求是由 `executionModel::linkStories()` 拉进迭代的，而它只在用户点确认之后才执行；API 调用的是 `$control->create($projectID)`，`$confirm` 用默认值 `'no'`，所以计划挂上了，需求一条都没进来，而且接口返回成功、没有任何提示。

## 修改

给同一个入口补上 `post()` 与 `delete()`：

```
POST   /api.php/v1/executions/:id/stories            {"stories": [126, 127]}
  201  {"execution": 111, "stories": [126, 127]}

DELETE /api.php/v1/executions/:id/stories/:storyID
  200  {"message": "success"}
```

- `post()` 照搬 `executionModel::linkStories()` 的顺序：先关联到项目，再关联到迭代。
- `delete()` 调用 `executionModel::unlinkStory()`，保留它原有的约束：需求被冻结、或项目下仍有子迭代关联着该需求时，返回 400 并带上模型给出的错误。
- 需求的过滤（草稿/评审中/已关闭、需求类型、看板泳道等）全部交给模型原有逻辑，入口不重复判断。

集合路由 `/executions/:id/stories` 本来就存在，只为 `delete()` 增加了一条两段式路由。

## 验证

在 22.5（`easysoft/zentao:22.5-20260821-php7`）上，用 API 走通一遍 Scrum 流程：建产品 → 建项目 → 提 3 条需求并评审通过 → 建迭代 → 关联 → `GET` 返回 `total: 3` → 解除其中一条 → `GET` 返回 `total: 2` 且剩下的正是未解除的两条。打补丁前，关联那一步之后始终是 `total: 0`。

边界情况：迭代不存在返回 404；解除一条并未关联的需求，模型层是静默的，因此返回 200（与 `DELETE /tasks/:id` 等入口的行为一致）。

> 注意：需要配合 #198 一起用。API 创建的项目 `storyType` 为空，`linkStory()` 会因此跳过所有需求，所以在只打本 PR 的情况下，用 API 新建的项目仍然关联不上（用界面创建的项目不受影响）。两个改动互相独立，可分别评审。

---

**Summary (EN):** API v1 can read an execution's stories but cannot link or unlink any — the entry only implements `get()`, and the only `linkstories` route targets product plans. Passing `plans` to execution creation does not help either: the stories of a plan are pulled in by `executionModel::linkStories()`, which only runs after the user confirms in the web flow, while the API calls `create($projectID)` with `$confirm` left at `'no'`. This adds `post()` (mirroring `linkStories()`: project first, then execution) and `delete()` (calling `unlinkStory()`, keeping its guards, surfaced as 400) to the same entry; the collection route already existed, a two-segment route is added for the delete. Verified on 22.5; needs #198 as well for projects created through the API.
